### PR TITLE
UNIVERSAL does more than `can` and `isa`

### DIFF
--- a/lib/mop/internals/mro.pm
+++ b/lib/mop/internals/mro.pm
@@ -73,8 +73,8 @@ sub find_method {
     # built-in methods such
     # as DOES, VERSION and
     # potentially others
-    if (my $universally = 'UNIVERSAL'->UNIVERSAL::can($method_name)) {
-        return $universally if ref($universally) eq q(CODE);
+    if (my $universally = 'UNIVERSAL'->can($method_name)) {
+        return $universally;
     }
 
     return;
@@ -105,10 +105,6 @@ sub call_method {
     my $method = find_submethod( $invocant, $method_name, %opts );
     $method    = find_method( $invocant, $method_name, %opts )
         unless defined $method;
-    $method = do {
-        my $real = UNIVERSAL->can("frobnicate");
-        eval q{ sub () { goto $real } };
-    } unless defined $method;
 
     # XXX 
     # this is f-ing stupid, but under `make test`

--- a/t/110-oddities/011-universal-methods.t
+++ b/t/110-oddities/011-universal-methods.t
@@ -27,7 +27,7 @@ can_ok("Foo", "frobnicate");
 can_ok($foo, "frobnicate");
 is(Foo->can("frobnicate")->(), 42, 'Foo->can("frobnicate")->() is 42');
 is($foo->can("frobnicate")->(), 42, '$foo->can("frobnicate")->() is 42');
-is(Foo->frobincate, 42, 'Foo->frobincate is 42');
-is($foo->frobincate, 42, '$foo->frobincate is 42');
+is(Foo->frobnicate, 42, 'Foo->frobnicate is 42');
+is($foo->frobnicate, 42, '$foo->frobnicate is 42');
 
 done_testing;


### PR DESCRIPTION
This patch allows mop classes to inherit whatever other methods UNIVERSAL provides.

The standard UNIVERSAL package provides `DOES` and `VERSION`, though of course people can monkey-patch it with whatever the hell else they like.
