### PR TITLE
Improvements for overloading

### DIFF
--- a/t/200-meta/040-overload.t
+++ b/t/200-meta/040-overload.t
@@ -17,6 +17,12 @@ class Thing2 extends Thing1 is overload('inherited') {
 	}
 }
 
+class Thing3 {
+	has $name is overload(q[""]);
+}
+
+class Thing4 extends Thing3 is overload('inherited') { }
+
 my $thing1 = 'Thing1'->new(name => 'foo');
 is("$thing1", 'foo');
 
@@ -25,5 +31,11 @@ is("$thing1", 'foo');
 	my $thing2 = 'Thing2'->new(name => 'bar');
 	is("$thing2", 'BAR');
 }
+
+my $thing3 = 'Thing3'->new(name => 'baz');
+is("$thing3", 'baz');
+
+my $thing4 = 'Thing4'->new(name => 'quux');
+is("$thing4", 'quux');
 
 done_testing;


### PR DESCRIPTION
- Test cases for overloading, including a TODO (for which I'll file a separate issue).
- Allow attributes to take part in overloading without needing an accessor. This only makes sense for unary-like overloads.

``` perl
class Person {
       has $name is overload(q[""]);
}
```
