### PR TITLE
Support for the PACKAGE VERSION syntax

### DIFF
--- a/lib/mop/internals/syntax.pm
+++ b/lib/mop/internals/syntax.pm
@@ -10,6 +10,7 @@ use B::Hooks::EndOfScope ();
 use Scalar::Util    ();
 use Sub::Name       ();
 use Module::Runtime ();
+use version         ();
 
 use Parse::Keyword {
     class     => \&namespace_parser,
@@ -118,6 +119,14 @@ sub namespace_parser {
 
     lex_read_space;
 
+    my $version;
+    if (lex_peek(40) =~ / \A ($version::LAX) (?:\s|\{) /x) {
+        lex_read(length($1));
+        $version = version::is_strict($1) ? eval($1) : $1 eq 'undef' ? undef : $1;
+    }
+
+    lex_read_space;
+
     my @classes_to_load;
 
     my $extends;
@@ -162,6 +171,7 @@ sub namespace_parser {
         extends   => $extends,
         with      => \@with,
         metaclass => $metaclass,
+        version   => $version,
     );
     mop::util::get_stash_for($pkg)->add_symbol('$METACLASS', \$meta);
     my $g = guard {

--- a/t/150-parser-tests/010-version.t
+++ b/t/150-parser-tests/010-version.t
@@ -1,0 +1,28 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use mop;
+
+class Foo 1.0 {}
+is(mop::get_meta('Foo')->version, 1.0, 'can parse version "1.0"');
+
+class Bar 1.00_02 extends Foo {}
+is(mop::get_meta('Bar')->version, '1.00_02', 'can parse version "1.00_02"');
+
+class Baz v1.2.3 extends Foo {}
+is(mop::get_meta('Baz')->version, v1.2.3, 'can parse version "v1.2.3"');
+
+role Quux 1.2.3 {}
+is(mop::get_meta('Quux')->version, '1.2.3', 'can parse version "1.2.3"');
+
+role Quuux undef {}
+is(mop::get_meta('Quuux')->version, undef, 'can parse version "undef"');
+
+role Xyzzy 42 {}
+is(mop::get_meta('Xyzzy')->version, 42, 'can parse version "42"');
+
+done_testing;


### PR DESCRIPTION
Since 5.14, Perl has supported this syntax for declaring a version number for a package:

```
package Foo 1.0 {
    ....;
}
```

This pull request adds similar version declaration to the `class` and `role` keywords:

```
role Foo 1.0 {
    ...;
}
class Bar 1.0 with Foo {
    ...;
}
```
