### PR TITLE
test for incorrect importing behavior

### DIFF
--- a/t/120-bugs/002-plack-parser-bug.t
+++ b/t/120-bugs/002-plack-parser-bug.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use lib 't/lib';
+
+use Bar::Class1;
+
+pass;
+
+done_testing;

--- a/t/lib/Bar.pm
+++ b/t/lib/Bar.pm
@@ -1,0 +1,11 @@
+package main;
+use strict;
+use warnings;
+
+use mop;
+use Bar::Class2;
+
+class Bar {
+}
+
+1;

--- a/t/lib/Bar/Class1.pm
+++ b/t/lib/Bar/Class1.pm
@@ -1,0 +1,11 @@
+package Bar;
+use strict;
+use warnings;
+
+use mop;
+use Bar;
+
+class Class1 {
+}
+
+1;

--- a/t/lib/Bar/Class2.pm
+++ b/t/lib/Bar/Class2.pm
@@ -1,0 +1,8 @@
+package Bar;
+use strict;
+use warnings;
+
+class Class2 {
+}
+
+1;


### PR DESCRIPTION
This is an example of code which breaks because of the current auto-unimport behavior. I think we should probably just not mess with auto-unimporting at all, and let code that actually runs into conflicts worry about cleaning out their stashes if necessary.
