### PR TITLE
Add TODO test for cleanup bug in parsing failure

### DIFF
--- a/t/150-parser-tests/050-errors.t
+++ b/t/150-parser-tests/050-errors.t
@@ -17,4 +17,21 @@ class Bar:Bar { }
 ';
 like($@, qr/^Invalid identifier: Bar:Bar/);
 
+TODO: {
+    local $TODO = "Need to fix error handling on parser errors";
+    my $capture;
+    local $SIG{__WARN__} = sub { $capture .= "@_" };
+
+    eval '
+        class Bar { method foo {}, }
+    ';
+
+    undef $SIG{__WARN__};
+
+    # Probably replace these with a strict check for actual error once it's decided
+    # what that error should be 
+    unlike($@, qr/Undefined subroutine called/, 'Parser error doesn\'t do weird things');
+    unlike($capture, qr/Attempt to free unreferenced scalar/, 'Parser error doesn\'t do weird things');
+}
+
 done_testing;


### PR DESCRIPTION
This currently breaks weirdly:

```
    $ perl -Mop -e 'class cat { method meow {}, }'
    syntax error at -e line 1, near "},"
    Undefined subroutine called at -e line 1.
    Attempt to free unreferenced scalar: SV 0x1ce61a0 at -e line 1.
```

Included is a few tests (that will need fixing up with proper errors) to illustrate this test, currently under a TODO.
