### PR TITLE
Add TODO test for parsing 'has...' outside of 'class ...' parsing failur...

### DIFF
--- a/t/150-parser-tests/050-errors.t
+++ b/t/150-parser-tests/050-errors.t
@@ -17,4 +17,13 @@ class Bar:Bar { }
 ';
 like($@, qr/^Invalid identifier: Bar:Bar/);
 
+TODO: {
+    local $TODO = "has ... outside of class {} throws weird error";
+
+    eval '
+        has $!x
+    ';
+    unlike($@, qr/Can't call method "attribute_class" on an undefined value/, '\'has...\' outside of Class has a good error');
+}
+
 done_testing;


### PR DESCRIPTION
e...

Included is a TODO test for this oddity:

```
    $ perl -Mop -e 'has $!x'
    Can't call method "attribute_class" on an undefined value at /home/mhorsfall/.perlbrew/libs/perl-5.18.1@new/lib/perl5/x86_64-linux/mop/internals/syntax.pm line 93.
```
