### PR TITLE
Attribute of static class means the default value for this attribute

### DIFF
--- a/lib/mop/traits.pm
+++ b/lib/mop/traits.pm
@@ -49,8 +49,20 @@ sub rw {
             name => $attr->key_name,
             body => sub {
                 my $self = shift;
-                $weak_attr->store_data_in_slot_for($self, shift) if @_;
-                $weak_attr->fetch_data_in_slot_for($self);
+                if (blessed $self) {
+                    $weak_attr->store_data_in_slot_for($self, shift) if @_;
+                    $weak_attr->fetch_data_in_slot_for($self);
+                }
+                else {
+                    if (@_) {
+                        my $data = shift;
+                        $weak_attr->set_default($data);
+                        $data;
+                    }
+                    else {
+                        $weak_attr->get_default if $weak_attr->has_default;
+                    }
+                }
             }
         )
     );
@@ -70,7 +82,12 @@ sub ro {
             body => sub {
                 my $self = shift;
                 die "Cannot assign to a read-only accessor" if @_;
-                $weak_attr->fetch_data_in_slot_for($self);
+                if (blessed $self) {
+                    $weak_attr->fetch_data_in_slot_for($self);
+                }
+                else {
+                    $weak_attr->get_default if $weak_attr->has_default;
+                }
             }
         )
     );

--- a/t/010-basics/028-attributes-in-class-methods.t
+++ b/t/010-basics/028-attributes-in-class-methods.t
@@ -25,4 +25,37 @@ class Foo {
 is(Foo->baz('BAR-class'), 'BAR-class');
 is(Foo->new->baz('BAR-instance'), 'BAR-instance');
 
+
+class A {
+    has $!a is rw = 1;
+    has $!b is rw = 2;
+}
+
+class B extends A {
+    has $!b is rw = 3;
+}
+
+is(A->a, 1, '... A->a == 1');
+is(A->b, 2, '... A->b == 2');
+is(B->a, 1, '... B->a == 1');
+is(B->b, 3, '... B->b == 3');
+
+is(A->a(11), 11, '... A->a(11) == 11');
+is(B->b(33), 33, '... B->b(33) == 33');
+
+is(A->a, 11, '... A->a == 11');
+is(B->a, 11, '... B->a == 11');
+is(B->b, 33, '... B->b == 33');
+
+my $b = B->new();
+
+isa_ok($b, 'B');
+is($b->a, 11, '... $b->a == 11');
+is($b->b, 33, '... $b->b == 33');
+
+is($b->a(111), 111, '... $b->a(111) == 111');
+
+is($b->a, 111, '... $b->a == 111');
+is(B->a, 11, '... B->a == 11');
+
 done_testing;


### PR DESCRIPTION
I've changed the behavior of generated accessors for static class. I think the best way is to read or change the default value of an attribute.

This is the same behavior as for Python classes:

``` python
class A:
    a = 1
    b = 2

class B(A):
    b = 3

print A.a # 1
print A.b # 2
print B.a # 1
print B.b # 3

A.a = 11
B.b = 33

print A.a # 11
print B.a # 11
print B.b # 33

b = B()

print b.a # 11
print b.b # 33

b.a = 111

print b.a # 111
print B.a # 11
```

The same example coded with mop and this patch:

``` perl
use v5.14;

use mop;

class A {
    has $!a is rw = 1;
    has $!b is rw = 2;
}

class B extends A {
    has $!b is rw = 3;
}

say A->a; # 1
say A->b; # 2
say B->a; # 1
say B->b; # 3

A->a(11);
B->b(33);

say A->a; # 11
say B->a; # 11
say B->b; # 33

my $b = B->new();

say $b->a; # 11
say $b->b; # 33

$b->a(111);

say $b->a; # 111
say B->a;  # 11
```
